### PR TITLE
Fix workflow for publishing on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,7 @@ jobs:
     needs: [wheels]
     name: Publish wheels to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     permissions:
       id-token: write


### PR DESCRIPTION
The workflow for publishing via a "Trusted Publisher" requires the environment to be set to `pypi`. This configurations is chosen by the publishing organisation (Equinor) for security reasons.