### PR TITLE
Enable compile-time optimisation for prebuilt wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,14 +23,20 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
+            cxx_flags: '-march=x86-64-v3'
           - os: macos-13
             arch: x86_64
             macos_target: '13.0'
             openmp_root: '/usr/local/opt/libomp'
+            cxx_flags: '-march=x86-64-v3'
           - os: macos-latest
             arch: arm64
             macos_target: '14.0'
             openmp_root: '/opt/homebrew/opt/libomp/'
+            # There is no obvious compile-time optimisation that we can choose
+            # here that is better than what the compiler chooses by default.
+            # Therefore, we don't specify anything for arm64.
+            cxx_flags:
 
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +69,8 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_target }}
             OpenMP_ROOT=${{ matrix.openmp_root }}
+          CIBW_ENVIRONMENT: >
+            CXXFLAGS='${{ matrix.cxx_flags }}'
         run: |
           python -m cibuildwheel --output-dir wheelhouse python
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ The pre-built wheels can be installed via `pip`
 pip install si4ti
 ```
 
+si4ti is compute intense and highly profits from compiler optimisation and
+vectorisation. Therefore, the prebuilt wheels have vectorisation enabled, but
+still aim for good portability. The `x86_64` wheels use `x86-64-v3`
+architecture optimisations which should be supported by Intel Haswell (released
+2013), AMD Excavator, and newer CPUs, see [the GCC documentation for more
+information](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) and overview
+of [microarchitecture levels on
+Wikipedia](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels). The
+`arm64` wheels are currently using the default optimisation chosen by the
+compiler and should be portable between all `arm64` platforms.
+
 ### Build from source ###
 You can install si4ti from source via the the Git repository. This allows to
 compile the package with FFTW3 support as well as platform specific

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "si4ti"
-version = "1.1.0a2"
+version = "1.1.0a3"
 description = "si4ti is a LGPL licensed seismic inversion tool for monitoring effects in 4D seismic from changes in acoustic properties of a reservoir."
 readme = "../README.md"
 authors = [


### PR DESCRIPTION
Vectorisation is crucial for good performance in si4ti as Eigen relies heavily on vectorisation. In tests on a x86_64 platform (Intel Xeon Platinum 8462Y+ using 8 cores), enabling target specific optimisation `x86-64-v3` [1] showed a reduction of runtime ~40% (from 60s to 38s wallclock time). Enabling newer archtitectures or `-march=native` did not show improved performance during our tests.

This impacts usability of the wheels as they only work on devices with support for the used instruction set. This should still be true for all reasonably new CPUs as as `x86-64-v3` refers to common CPUs with AVX2 such as Intel Haswell (released 2013) and AMD Excavator (released 2015) and newer "big cores" [2]. It is expected that people running the si4ti application are on powerful, reasonably new machines, and appreciate the performance gains. Mac users on arm64 Macs should be unaffected since do not turn any vectorisation features on besides the ones that are activated by default.

[1]: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
[2]: https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels